### PR TITLE
change builtin timer to safe-timers

### DIFF
--- a/platform/package.json
+++ b/platform/package.json
@@ -23,6 +23,7 @@
     "queue-fifo": "^0.2.5",
     "request": "^2.88.0",
     "request-promise": "^4.2.2",
+    "safe-timers": "^1.1.0",
     "tail": "^2.0.4",
     "ws": "^7.2.5"
   },

--- a/platform/sensor-stream-manager/policy.js
+++ b/platform/sensor-stream-manager/policy.js
@@ -1,4 +1,5 @@
 const cronParser = require('@huanglipang/cron-parser');
+const safeSetTimeout = require('safe-timers').setTimeout;
 
 class Schedule {
     constructor(cronPattern) {
@@ -371,13 +372,13 @@ class PolicyEnforcer {
         if(nextUpdateTime) {
             if(this.timer) {
                 // clear setTimeout when update policy
-                clearTimeout(this.timer);
+                this.timer.clear();
             }
             const now = new Date();
             // calculate the interval for next execution
             const interval = this._getTimeDifference(nextUpdateTime, now);
             console.log(`[INFO] Next update time: ${nextUpdateTime}, interval: ${interval}`);
-            this.timer = setTimeout(() => {
+            this.timer = safeSetTimeout(() => {
                 this._enforcePolicy();
             }, interval);
         }


### PR DESCRIPTION
change builtin timer to safe-timers because builtin timer cannot set the interval larger than 32-bit integer